### PR TITLE
Fix licensing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "homepage": "https://github.com/kesla/parse-headers",
   "devDependencies": {
-    "tape": "^4.2.2",
+    "tape": "^4.10.1",
     "zuul": "^3.7.2"
   },
   "dependencies": {
-    "for-each": "^0.3.2",
-    "trim": "0.0.1"
+    "for-each": "^0.3.3",
+    "string.prototype.trim": "^1.1.2"
   }
 }

--- a/parse-headers.js
+++ b/parse-headers.js
@@ -1,4 +1,4 @@
-var trim = require('trim')
+var trim = require('string.prototype.trim')
   , forEach = require('for-each')
   , isArray = function(arg) {
       return Object.prototype.toString.call(arg) === '[object Array]';


### PR DESCRIPTION
`string.prototype.trim` is MIT; `trim` is unlicensed. `for-each` 0.3.3 adds a SPDX-compliant license declaration.

I also updated tape.