### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
     "tape": "^4.10.1",
     "zuul": "^3.7.2"
   },
-  "dependencies": {
-    "for-each": "^0.3.3",
-    "string.prototype.trim": "^1.1.2"
-  }
+  "dependencies": {}
 }

--- a/parse-headers.js
+++ b/parse-headers.js
@@ -1,5 +1,6 @@
-var trim = require('string.prototype.trim')
-  , forEach = require('for-each')
+var trim = function(string) {
+  return string.replace(/^\s+|\s+$/g, '');
+}
   , isArray = function(arg) {
       return Object.prototype.toString.call(arg) === '[object Array]';
     }
@@ -10,22 +11,22 @@ module.exports = function (headers) {
 
   var result = {}
 
-  forEach(
-      trim(headers).split('\n')
-    , function (row) {
-        var index = row.indexOf(':')
-          , key = trim(row.slice(0, index)).toLowerCase()
-          , value = trim(row.slice(index + 1))
+  var headersArr = trim(headers).split('\n')
 
-        if (typeof(result[key]) === 'undefined') {
-          result[key] = value
-        } else if (isArray(result[key])) {
-          result[key].push(value)
-        } else {
-          result[key] = [ result[key], value ]
-        }
-      }
-  )
+  for (var i = 0; i < headersArr.length; i++) {
+    var row = headersArr[i]
+    var index = row.indexOf(':')
+    , key = trim(row.slice(0, index)).toLowerCase()
+    , value = trim(row.slice(index + 1))
+
+    if (typeof(result[key]) === 'undefined') {
+      result[key] = value
+    } else if (isArray(result[key])) {
+      result[key].push(value)
+    } else {
+      result[key] = [ result[key], value ]
+    }
+  }
 
   return result
 }


### PR DESCRIPTION
This PR removes the dependencies on `string.prototype.trim` and `for-each`.

`for-each` contains utilities to iterate over strings, arrays, and objects, and contains checks to handle lots of corner cases, but this package doesn't need any of that because it only iterates over one simple array.

`string.prototype.trim` [pulls in **13** dependencies](https://npm.anvaka.com/#/view/2d/string.prototype.trim). [These add up to 16KB minified/4KB gzipped.](https://bundlephobia.com/result?p=string.prototype.trim@1.2.0) The one-line function I replaced it with is equivalent to the original `trim` package removed in #6.