### PR TITLE
Define typings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.4",
   "description": "Parse http headers, works with browserify/xhr",
   "main": "parse-headers.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "node test.js"
   },


### PR DESCRIPTION
Currently npmjs doesn't recognize/declares available typings.