### PR TITLE
Use null-prototype instead to fix problems with default Object prototype keys

### DIFF
--- a/parse-headers.js
+++ b/parse-headers.js
@@ -9,7 +9,7 @@ module.exports = function (headers) {
   if (!headers)
     return {}
 
-  var result = {}
+  var result = Object.create(null);
 
   var headersArr = trim(headers).split('\n')
 


### PR DESCRIPTION
This fixes a problem that might become security-relevant depending on how `parse-headers` is used.